### PR TITLE
A first try to source tweets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+twitter-source.properties
 /kafka-connect-twitter.iml
 /.idea
 # sbt specific

--- a/README.md
+++ b/README.md
@@ -4,3 +4,8 @@
 Kafka Connect Source for Twitter
 
 Work in progress!
+
+## Todo:
+ - [ ] Extend
+ - [ ] Test
+ - [ ] Document

--- a/connect-standalone.properties
+++ b/connect-standalone.properties
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# These are defaults. This file just demonstrates how to override some settings.
+bootstrap.servers=localhost:9092
+
+# The converters specify the format of data in Kafka and how to translate it into Connect data. Every Connect user will
+# need to configure these based on the format they want their data in when loaded from or stored into Kafka
+#key.converter=org.apache.kafka.connect.json.JsonConverter
+#value.converter=org.apache.kafka.connect.json.JsonConverter
+key.converter=io.confluent.connect.avro.AvroConverter
+key.converter.schema.registry.url=http://localhost:8081
+value.converter=io.confluent.connect.avro.AvroConverter
+value.converter.schema.registry.url=http://localhost:8081
+
+# Converter-specific settings can be passed in by prefixing the Converter's setting with the converter we want to apply
+# it to
+key.converter.schemas.enable=true
+value.converter.schemas.enable=true
+
+o
+# The internal converter used for offsets and config data is configurable and must be specified, but most users will
+# always want to use the built-in default. Offset and config data is never visible outside of Copcyat in this format.
+internal.key.converter=org.apache.kafka.connect.json.JsonConverter
+internal.value.converter=org.apache.kafka.connect.json.JsonConverter
+internal.key.converter.schemas.enable=false
+internal.value.converter.schemas.enable=false
+
+offset.storage.file.filename=/tmp/connect.offsets
+# Flush much faster than normal, which is useful for testing/debugging
+offset.flush.interval.ms=10000

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         </dependency>
         <dependency>
             <groupId>com.twitter</groupId>
-            <artifactId>hbc-core</artifactId>
+            <artifactId>hbc-twitter4j</artifactId>
             <version>${hosebird.version}</version>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,11 @@
             <artifactId>hbc-twitter4j</artifactId>
             <version>${hosebird.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>1.8.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/scala/com/eneco/trading/kafka/connect/twitter/TwitterReader.scala
+++ b/src/main/scala/com/eneco/trading/kafka/connect/twitter/TwitterReader.scala
@@ -23,16 +23,16 @@ object TwitterReader {
       config.getString(TwitterSourceConfig.TOKEN_CONFIG),
       config.getString(TwitterSourceConfig.SECRET_CONFIG))
 
-    val queue= new LinkedBlockingQueue[String](10000)
+    val queue = new LinkedBlockingQueue[String](10000)
 
     val client = new ClientBuilder()
-                    .name(config.getString(TwitterSourceConfig.TWITTER_APP_NAME))
-                    .hosts(Constants.STREAM_HOST)
-                    .endpoint(endpoint)
-                    .authentication(auth)
-                    .processor(new StringDelimitedProcessor(queue))
-                    .build()
+      .name(config.getString(TwitterSourceConfig.TWITTER_APP_NAME))
+      .hosts(Constants.STREAM_HOST)
+      .endpoint(endpoint)
+      .authentication(auth)
+      .processor(new StringDelimitedProcessor(queue))
+      .build()
 
-    new TwitterStreamReader(client = client)
+    new TwitterStreamReader(client = client, rawqueue = queue)
   }
 }

--- a/src/main/scala/com/eneco/trading/kafka/connect/twitter/TwitterSourceConfig.scala
+++ b/src/main/scala/com/eneco/trading/kafka/connect/twitter/TwitterSourceConfig.scala
@@ -30,7 +30,7 @@ object TwitterSourceConfig {
         .define(CONSUMER_SECRET_CONFIG, Type.STRING, Importance.HIGH, CONSUMER_SECRET_CONFIG_DOC)
         .define(TOKEN_CONFIG, Type.STRING, Importance.HIGH, TOKEN_CONFIG_DOC)
         .define(SECRET_CONFIG, Type.STRING, Importance.HIGH, SECRET_CONFIG_DOC)
-        .define(TRACK_TERMS, Type.LIST, TRACK_TERMS_DEFAULT, Importance.LOW, SECRET_CONFIG_DOC)
+        .define(TRACK_TERMS, Type.LIST, TRACK_TERMS_DEFAULT, Importance.LOW, TRACK_TERMS_DOC)
         .define(TWITTER_APP_NAME, Type.STRING, TWITTER_APP_NAME_DEFAULT, Importance.HIGH, TWITTER_APP_NAME_DOC)
 }
 

--- a/src/main/scala/com/eneco/trading/kafka/connect/twitter/TwitterSourceConfig.scala
+++ b/src/main/scala/com/eneco/trading/kafka/connect/twitter/TwitterSourceConfig.scala
@@ -31,7 +31,7 @@ object TwitterSourceConfig {
         .define(TOKEN_CONFIG, Type.STRING, Importance.HIGH, TOKEN_CONFIG_DOC)
         .define(SECRET_CONFIG, Type.STRING, Importance.HIGH, SECRET_CONFIG_DOC)
         .define(TRACK_TERMS, Type.LIST, TRACK_TERMS_DEFAULT, Importance.LOW, SECRET_CONFIG_DOC)
-        .define(TWITTER_APP_NAME, Type.LIST, TWITTER_APP_NAME_DEFAULT, Importance.HIGH, TWITTER_APP_NAME_DOC)
+        .define(TWITTER_APP_NAME, Type.STRING, TWITTER_APP_NAME_DEFAULT, Importance.HIGH, TWITTER_APP_NAME_DOC)
 }
 
 class TwitterSourceConfig(props: util.Map[String, String])

--- a/src/main/scala/com/eneco/trading/kafka/connect/twitter/TwitterStreamReader.scala
+++ b/src/main/scala/com/eneco/trading/kafka/connect/twitter/TwitterStreamReader.scala
@@ -1,19 +1,14 @@
 package com.eneco.trading.kafka.connect.twitter
 
 import java.util.Collections
-import java.util.concurrent.{Executors, TimeUnit, LinkedBlockingQueue}
-
-import com.sun.xml.internal.ws.api.message.Packet
+import java.util.concurrent.{Executors, LinkedBlockingQueue, TimeUnit}
 import com.twitter.hbc.httpclient.BasicClient
 import com.twitter.hbc.twitter4j.Twitter4jStatusClient
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
-import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.connect.source.SourceRecord;
-import org.apache.kafka.connect.data.Struct
+import org.apache.kafka.connect.data.{Schema, SchemaBuilder, Struct}
 import org.apache.kafka.connect.source.SourceRecord
-import twitter4j.{StallWarning, Status, StatusDeletionNotice, StatusListener}
+import twitter4j._
 import scala.collection.JavaConverters._
+
 
 class StatusEnqueuer(queue: LinkedBlockingQueue[Status]) extends StatusListener with Logging {
   override def onStallWarning(stallWarning: StallWarning): Unit = {
@@ -42,6 +37,51 @@ class StatusEnqueuer(queue: LinkedBlockingQueue[Status]) extends StatusListener 
   }
 }
 
+case class TwitterStatus(id: Long, createdAt: String, favoriteCount: Int, text: String, user: TwitterUser)
+case class TwitterUser(id: Long, name: String, screenName: String)
+
+object TwitterUser {
+  def apply(u: User) = {
+    new TwitterUser(id = u.getId, name = u.getName, screenName = u.getScreenName)
+  }
+
+  def struct(u: TwitterUser) =
+    new Struct(schema)
+      .put("id", u.id)
+      .put("name", u.name)
+      .put("screenName", u.screenName)
+
+  val schema = SchemaBuilder.struct().name("TwitterUser")
+    .field("id", Schema.INT64_SCHEMA)
+    .field("name", Schema.STRING_SCHEMA)
+    .field("screenName", Schema.STRING_SCHEMA)
+    .build()
+}
+
+object TwitterStatus {
+  def apply(s: Status) = {
+    new TwitterStatus(id = s.getId, createdAt = s.getCreatedAt.toString, favoriteCount = s.getFavoriteCount, text = s.getText, user = TwitterUser(s.getUser))
+  }
+
+  def struct(s: TwitterStatus) =
+    new Struct(schema)
+      .put("id", s.id)
+      .put("createdAt", s.createdAt)
+      .put("favoriteCount", s.favoriteCount)
+      .put("text", s.text)
+      .put("user", TwitterUser.struct(s.user))
+
+  val schema = SchemaBuilder.struct().name("TwitterStatus")
+    .field("id", Schema.INT64_SCHEMA)
+    .field("createdAt", Schema.STRING_SCHEMA)
+    .field("favoriteCount", Schema.INT32_SCHEMA)
+    .field("text", Schema.STRING_SCHEMA)
+    .field("user", TwitterUser.schema)
+    .build()
+}
+
+
+
 /**
   * Created by andrew@datamountaineer.com on 24/02/16. 
   * kafka-connect-twitter
@@ -62,12 +102,8 @@ class TwitterStreamReader(client: BasicClient, rawqueue: LinkedBlockingQueue[Str
     }
     return Option(statusqueue.poll(1, TimeUnit.SECONDS)) match {
       case Some(status) => {
-        val sch = SchemaBuilder.struct().name("status")
-            .field("text",Schema.STRING_SCHEMA)
-          .field("user",Schema.STRING_SCHEMA)
-          .build()
-        val s = new Struct(sch).put("text",status.getText).put("user",status.getUser.getScreenName)
-        List[SourceRecord](new SourceRecord(Collections.singletonMap("TODO", "TODO"), Collections.singletonMap("TODO2", "TODO2"), "test", sch, s))
+        val ts = TwitterStatus.struct(TwitterStatus(status))
+        List[SourceRecord](new SourceRecord(Collections.singletonMap("TODO", "TODO"), Collections.singletonMap("TODO2", "TODO2"), "tweeters", ts.schema(), ts))
       }
       case _ => List[SourceRecord]()
     }

--- a/src/main/scala/com/eneco/trading/kafka/connect/twitter/TwitterStreamReader.scala
+++ b/src/main/scala/com/eneco/trading/kafka/connect/twitter/TwitterStreamReader.scala
@@ -1,9 +1,16 @@
 package com.eneco.trading.kafka.connect.twitter
 
+import java.util.Collections
 import java.util.concurrent.{Executors, TimeUnit, LinkedBlockingQueue}
 
+import com.sun.xml.internal.ws.api.message.Packet
 import com.twitter.hbc.httpclient.BasicClient
 import com.twitter.hbc.twitter4j.Twitter4jStatusClient
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.data.Struct
 import org.apache.kafka.connect.source.SourceRecord
 import twitter4j.{StallWarning, Status, StatusDeletionNotice, StatusListener}
 import scala.collection.JavaConverters._
@@ -53,14 +60,17 @@ class TwitterStreamReader(client: BasicClient, rawqueue: LinkedBlockingQueue[Str
       log.warn("Client connection closed unexpectedly: ", client.getExitEvent.getMessage)
       return null;
     }
-    Option(statusqueue.poll(1, TimeUnit.SECONDS)) match {
-      case Some(msg) => {
-        log.info(msg.getText)
-        return List[SourceRecord]()
+    return Option(statusqueue.poll(1, TimeUnit.SECONDS)) match {
+      case Some(status) => {
+        val sch = SchemaBuilder.struct().name("status")
+            .field("text",Schema.STRING_SCHEMA)
+          .field("user",Schema.STRING_SCHEMA)
+          .build()
+        val s = new Struct(sch).put("text",status.getText).put("user",status.getUser.getScreenName)
+        List[SourceRecord](new SourceRecord(Collections.singletonMap("TODO", "TODO"), Collections.singletonMap("TODO2", "TODO2"), "test", sch, s))
       }
-      case _ => return List[SourceRecord]()
+      case _ => List[SourceRecord]()
     }
-    List[SourceRecord]()
   }
 
   /**

--- a/src/main/scala/com/eneco/trading/kafka/connect/twitter/TwitterStreamReader.scala
+++ b/src/main/scala/com/eneco/trading/kafka/connect/twitter/TwitterStreamReader.scala
@@ -1,18 +1,67 @@
 package com.eneco.trading.kafka.connect.twitter
 
+import java.util.concurrent.{Executors, TimeUnit, LinkedBlockingQueue}
+
 import com.twitter.hbc.httpclient.BasicClient
+import com.twitter.hbc.twitter4j.Twitter4jStatusClient
 import org.apache.kafka.connect.source.SourceRecord
+import twitter4j.{StallWarning, Status, StatusDeletionNotice, StatusListener}
+import scala.collection.JavaConverters._
+
+class StatusEnqueuer(queue: LinkedBlockingQueue[Status]) extends StatusListener with Logging {
+  override def onStallWarning(stallWarning: StallWarning): Unit = {
+    log.warn("onStallWarning")
+  }
+
+  override def onDeletionNotice(statusDeletionNotice: StatusDeletionNotice): Unit = {
+    log.info("onDeletionNotice")
+  }
+
+  override def onScrubGeo(l: Long, l1: Long): Unit = {
+    log.info(s"onScrubGeo $l $l1")
+  }
+
+  override def onStatus(status: Status): Unit = {
+    log.info("onStatus")
+    queue.put(status)
+  }
+
+  override def onTrackLimitationNotice(i: Int): Unit = {
+    log.info(s"onTrackLimitationNotice $i")
+  }
+
+  override def onException(e: Exception): Unit = {
+    log.warn("onException " + e.toString)
+  }
+}
 
 /**
   * Created by andrew@datamountaineer.com on 24/02/16. 
   * kafka-connect-twitter
   */
-class TwitterStreamReader(client: BasicClient) extends Logging {
+class TwitterStreamReader(client: BasicClient, rawqueue: LinkedBlockingQueue[String]) extends Logging {
   log.info("Initialising Twitter Stream Reader")
-  client.connect()
+  val statusqueue = new LinkedBlockingQueue[Status](10000)
 
+  val t4jclient = new Twitter4jStatusClient(client, rawqueue, List[StatusListener](new StatusEnqueuer(statusqueue)).asJava, Executors.newFixedThreadPool(1) )
+  t4jclient.connect()
+  t4jclient.process()
 
-  def poll() : List[SourceRecord] = ???
+  def poll() : List[SourceRecord] = {
+    log.info("poll")
+    if (client.isDone) {
+      log.warn("Client connection closed unexpectedly: ", client.getExitEvent.getMessage)
+      return null;
+    }
+    Option(statusqueue.poll(1, TimeUnit.SECONDS)) match {
+      case Some(msg) => {
+        log.info(msg.getText)
+        return List[SourceRecord]()
+      }
+      case _ => return List[SourceRecord]()
+    }
+    List[SourceRecord]()
+  }
 
   /**
     * Stop the HBC client

--- a/twitter-source.properties.example
+++ b/twitter-source.properties.example
@@ -1,0 +1,8 @@
+name=twitter-source
+connector.class=com.eneco.trading.kafka.connect.twitter.TwitterSourceConnector
+tasks.max=1
+topic=test
+twitter.consumerkey=
+twitter.consumersecret=
+twitter.token=
+twitter.secret=


### PR DESCRIPTION
I initially tried to automatically derive a `Schema` and fill in a `org.apache.kafka.connect.data.Struct` through serialisation, which proved to be a bit too ambitious for a 2nd day of Scala. Now I do it manually. Still, I think it shouldn't be done manually in the end, a (Twitter) `Status` contains a lot of fields, my current demo code does:

```scala
    new Struct(schema)
      .put("id", s.id)
      .put("createdAt", s.createdAt)
      .put("favoriteCount", s.favoriteCount)
      .put("text", s.text)
      .put("user", TwitterUser.struct(s.user))

  val schema = SchemaBuilder.struct().name("TwitterStatus")
    .field("id", Schema.INT64_SCHEMA)
    .field("createdAt", Schema.STRING_SCHEMA)
    .field("favoriteCount", Schema.INT32_SCHEMA)
    .field("text", Schema.STRING_SCHEMA)
    .field("user", TwitterUser.schema)
    .build()
```

... which will get really huge when we include all fields.

- No tests yet
- No idiomatic Scala. I intend to look into those implicit conversions.