### PR TITLE
Add sample streaming & extend functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 # sbt specific
 target/
 # Scala-IDE specific
+/twitter-source.properties
+/.settings
+/.project
+/.classpath

--- a/README.md
+++ b/README.md
@@ -13,19 +13,33 @@ Properties
 
 In addition to the default topics configuration the following options are added:
 
-| name                     | data type | required | default | description                     |
-|:-------------------------|:----------|:---------|:--------|:--------------------------------|
-| `twitter.consumerkey`    | string    | yes      |         | Twitter consumer key            |
-| `twitter.consumersecret` | string    | yes      |         | Twitter consumer secret         |
-| `twitter.token`          | string    | yes      |         | Twitter token                   |
-| `twitter.secret`         | string    | yes      |         | Twitter secret                  |
-| `track.terms`            | string    | yes      |         | A Twitter `track` parameter ¹   |
-| `batch.size`             | int       | no       | 100     | Flush after this many tweets ²  |
-| `batch.timeout`          | double    | no       | 0.1     | Flush after this many seconds ² |
+| name                     | data type | required | default | description                         |
+|:-------------------------|:----------|:---------|:--------|:------------------------------------|
+| `twitter.consumerkey`    | string    | yes      |         | Twitter consumer key                |
+| `twitter.consumersecret` | string    | yes      |         | Twitter consumer secret             |
+| `twitter.token`          | string    | yes      |         | Twitter token                       |
+| `twitter.secret`         | string    | yes      |         | Twitter secret                      |
+| `stream.type`            | string    | no       | filter  | Type of stream ¹                    |
+| `track.terms`            | string    | maybe ²  |         | A Twitter `track` parameter ²       |
+| `track.locations`        | string    | maybe ²  |         | A Twitter `locations` parameter ³   |
+| `track.follow`           | string    | maybe ²  |         | A Twitter `follow` parameter ⁴      |
+| `batch.size`             | int       | no       | 100     | Flush after this many tweets ⁶      |
+| `batch.timeout`          | double    | no       | 0.1     | Flush after this many seconds ⁶     |
+| `language`               | string    | no       |         | List of languages to fetch ⁷        |
 
-¹ Please refer to [here](https://dev.twitter.com/streaming/overview/request-parameters#track) for the format of the `track` parameter.
+¹ Type of stream: [filter](https://dev.twitter.com/streaming/reference/post/statuses/filter), or [sample](https://dev.twitter.com/streaming/reference/get/statuses/sample).
 
-² Tweets are accumulated and flushed as a batch into Kafka; when the batch is larger than `batch.size` or when the oldest tweet in it is older than `batch.timeout` [s], it is flushed.
+² When the `filter` type is used, one of the parameters `track.terms`, `track.locations`, or `track.follow` should be specified.  If multiple parameters are specified, they are working as OR operation.
+
+³ Please refer to [here](https://dev.twitter.com/streaming/overview/request-parameters#track) for the format of the `track` parameter.
+
+⁴ Please refer to [here](https://dev.twitter.com/streaming/overview/request-parameters#locations) for the format of the `locations` parameter.
+
+⁵ Please refer to [here](https://dev.twitter.com/streaming/overview/request-parameters#follow) for the format of the `follow` parameter.
+
+⁶ Tweets are accumulated and flushed as a batch into Kafka; when the batch is larger than `batch.size` or when the oldest tweet in it is older than `batch.timeout` [s], it is flushed.
+
+⁷ List of languages for which tweets will be returned. Can be used with any stream type.  See [here](https://dev.twitter.com/streaming/overview/request-parameters#language) for format of the `language` parameter.
 
 An example `twitter-source.properties`:
 
@@ -68,7 +82,7 @@ Starting kafka-connect-twitter
 
 Having cloned this repository, build the latest source code with:
 
-    mvn clean install
+    mvn clean package
 
 Put the JAR file location into your `CLASSPATH`:
 

--- a/src/main/scala/com/eneco/trading/kafka/connect/twitter/TwitterSourceConfig.scala
+++ b/src/main/scala/com/eneco/trading/kafka/connect/twitter/TwitterSourceConfig.scala
@@ -4,9 +4,11 @@ import java.util
 
 import org.apache.kafka.common.config.{AbstractConfig, ConfigDef}
 import org.apache.kafka.common.config.ConfigDef.{Type, Importance}
+import scala.collection.JavaConversions._
+import scala.util.{Failure, Try}
 
 /**
-  * Created by andrew@datamountaineer.com on 24/02/16. 
+  * Created by andrew@datamountaineer.com on 24/02/16.
   * kafka-connect-twitter
   */
 object TwitterSourceConfig {
@@ -18,8 +20,17 @@ object TwitterSourceConfig {
   val TOKEN_CONFIG_DOC = "Twitter account token."
   val SECRET_CONFIG = "twitter.secret"
   val SECRET_CONFIG_DOC = "Twitter account secret."
+  val STREAM_TYPE = "stream.type"
+  val STREAM_TYPE_DOC = "Twitter stream type (filter or sample)."
+  val STREAM_TYPE_FILTER = "filter"
+  val STREAM_TYPE_SAMPLE = "sample"
+  val STREAM_TYPE_DEFAULT = STREAM_TYPE_FILTER
   val TRACK_TERMS = "track.terms"
   val TRACK_TERMS_DOC = "Twitter terms to track."
+  val TRACK_LOCATIONS = "track.locations"
+  val TRACK_LOCATIONS_DOC = "Geo locations to track."
+  val TRACK_FOLLOW = "track.follow"
+  val TRACK_FOLLOW_DOC = "User IDs to track."
   val TWITTER_APP_NAME = "twitter.app.name"
   val TWITTER_APP_NAME_DOC = "Twitter app name"
   val TWITTER_APP_NAME_DEFAULT = "KafkaConnectTwitterSource"
@@ -32,21 +43,61 @@ object TwitterSourceConfig {
   val TOPIC = "topic"
   val TOPIC_DOC = "The Kafka topic to append to"
   val TOPIC_DEFAULT = "tweets"
+  val LANGUAGE = "language"
+  val LANGUAGE_DOC = "List of languages to filter"
+  val EMPTY_VALUE = ""
 
   val config: ConfigDef = new ConfigDef()
     .define(CONSUMER_KEY_CONFIG, Type.STRING, Importance.HIGH, CONSUMER_KEY_CONFIG_DOC)
     .define(CONSUMER_SECRET_CONFIG, Type.STRING, Importance.HIGH, CONSUMER_SECRET_CONFIG_DOC)
     .define(TOKEN_CONFIG, Type.STRING, Importance.HIGH, TOKEN_CONFIG_DOC)
     .define(SECRET_CONFIG, Type.STRING, Importance.HIGH, SECRET_CONFIG_DOC)
-    .define(TRACK_TERMS, Type.LIST, Importance.HIGH, TRACK_TERMS_DOC)
+    .define(STREAM_TYPE, Type.STRING, STREAM_TYPE_DEFAULT, Importance.HIGH, STREAM_TYPE_DOC)
+    .define(TRACK_TERMS, Type.LIST, EMPTY_VALUE, Importance.MEDIUM, TRACK_TERMS_DOC)
+    .define(TRACK_FOLLOW, Type.LIST, EMPTY_VALUE, Importance.MEDIUM, TRACK_FOLLOW_DOC)
+    .define(TRACK_LOCATIONS, Type.LIST, EMPTY_VALUE, Importance.MEDIUM, TRACK_LOCATIONS_DOC)
     .define(TWITTER_APP_NAME, Type.STRING, TWITTER_APP_NAME_DEFAULT, Importance.HIGH, TWITTER_APP_NAME_DOC)
     .define(BATCH_SIZE, Type.INT, BATCH_SIZE_DEFAULT, Importance.MEDIUM, BATCH_SIZE_DOC)
     .define(BATCH_TIMEOUT, Type.DOUBLE, BATCH_TIMEOUT_DEFAULT, Importance.MEDIUM, BATCH_TIMEOUT_DOC)
     .define(TOPIC, Type.STRING, TOPIC_DEFAULT, Importance.HIGH, TOPIC_DOC)
+    .define(LANGUAGE, Type.LIST, EMPTY_VALUE, Importance.MEDIUM, LANGUAGE_DOC)
 }
 
 class TwitterSourceConfig(props: util.Map[String, String])
   extends AbstractConfig(TwitterSourceConfig.config, props) {
+    getString(TwitterSourceConfig.STREAM_TYPE) match {
+      case TwitterSourceConfig.STREAM_TYPE_SAMPLE => {}
+      case TwitterSourceConfig.STREAM_TYPE_FILTER => {
+        val terms = getList(TwitterSourceConfig.TRACK_TERMS)
+        val locations = getList(TwitterSourceConfig.TRACK_LOCATIONS)
+        val users = getList(TwitterSourceConfig.TRACK_FOLLOW)
+        val language = getList(TwitterSourceConfig.LANGUAGE)
+        if (terms.isEmpty && locations.isEmpty && users.isEmpty) {
+          throw new RuntimeException("At least one of the parameters "
+              + TwitterSourceConfig.TRACK_TERMS + ", " + TwitterSourceConfig.TRACK_LOCATIONS
+              + ", " + TwitterSourceConfig.TRACK_FOLLOW + " should be specified!")
+        }
+        if (!locations.isEmpty) {
+          if ((locations.size % 4) != 0) {
+            throw new RuntimeException(TwitterSourceConfig.TRACK_LOCATIONS
+                + " should have number of elements divisible by 4!")
+          }
+          try {
+            locations.toList.map { x => x.trim.toDouble}
+          } catch {
+            case e: NumberFormatException => throw new RuntimeException("You should use double numbers in "
+                + TwitterSourceConfig.TRACK_LOCATIONS)
+          }
+        }
+        try {
+            users.toList.map { x => x.trim.toLong}
+        } catch {
+          case e: NumberFormatException => throw new RuntimeException("You should use numeric user IDs in "
+              + TwitterSourceConfig.TRACK_FOLLOW)
+        }
+      }
+      case _ => throw new RuntimeException("Unknown value for "
+          + TwitterSourceConfig.STREAM_TYPE + " parameter")
+    }
+
 }
-
-

--- a/src/main/scala/com/eneco/trading/kafka/connect/twitter/TwitterSourceConnector.scala
+++ b/src/main/scala/com/eneco/trading/kafka/connect/twitter/TwitterSourceConnector.scala
@@ -38,7 +38,8 @@ class TwitterSourceConnector extends Connector with Logging {
     log.info(s"Starting Twitter source task with ${props.toString}.")
     configProps = props
     Try(new TwitterSourceConfig(props)) match {
-      case Failure(f) => throw new ConnectException("Couldn't start Twitter source due to configuration error.", f)
+      case Failure(f) => throw new ConnectException("Couldn't start Twitter source due to configuration error: "
+          + f.getMessage, f)
       case _ =>
     }
   }

--- a/src/main/scala/com/eneco/trading/kafka/connect/twitter/TwitterSourceTask.scala
+++ b/src/main/scala/com/eneco/trading/kafka/connect/twitter/TwitterSourceTask.scala
@@ -4,7 +4,7 @@ import java.util
 import org.apache.kafka.connect.source.{SourceRecord, SourceTask}
 
 /**
-  * Created by andrew@datamountaineer.com on 24/02/16. 
+  * Created by andrew@datamountaineer.com on 24/02/16.
   * kafka-connect-twitter
   */
 class TwitterSourceTask extends SourceTask with Logging {

--- a/twitter-source.properties.example
+++ b/twitter-source.properties.example
@@ -6,3 +6,11 @@ twitter.consumerkey=
 twitter.consumersecret=
 twitter.token=
 twitter.secret=
+# language=en,ru,de
+# stream.type=sample
+# stream.type=filter
+# track.terms=news,music,hadoop,clojure,scala,fp,golang,python,fsharp,cpp,java
+# San Francisco OR New York City
+#track.locations=-122.75,36.8,-121.75,37.8,-74,40,-73,41
+# bbcbreaking,bbcnews,justinbieber
+# track.follow=5402612,612473,27260086


### PR DESCRIPTION
This includes following changes:
 - `stream.type` parameter was added to select between `filter` & `sample`
   streams;
 - Besides the `track.terms`, support for the `track.locations` &
   `track.follow` parameters were added;
 - The `language` parameter was added to return only tweets in given
   languages. This works for any stream type;
 - Configuration is now checked during startup (fixes #12).

See README for more information about new parameters.

This should fix issue #12 and #13