### PR TITLE
simplify pom.xml & make it working with eclipse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ target/
 /.settings
 /.project
 /.classpath
+/.cache-main
+/.cache-tests

--- a/pom.xml
+++ b/pom.xml
@@ -193,17 +193,10 @@
                 </configuration>
                 <executions>
                     <execution>
-                        <id>scala-compile</id>
-                        <phase>process-resources</phase>
                         <goals>
-                            <goal>compile</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>scala-test-compile</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>testCompile</goal>
+                          <goal>compile</goal>
+                          <goal>add-source</goal>
+                          <goal>testCompile</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
to make m2eclipse-scala work with Scala source code I was need to add
the `add-source` goal.  I also removed not necessary executions as the
Scala Maven plugin itself hooks into correct phases.