### PR TITLE
Simple key value string source

### DIFF
--- a/src/main/scala/com/eneco/trading/kafka/connect/twitter/TwitterReader.scala
+++ b/src/main/scala/com/eneco/trading/kafka/connect/twitter/TwitterReader.scala
@@ -10,7 +10,8 @@ import com.twitter.hbc.core.endpoint.DefaultStreamingEndpoint
 import com.twitter.hbc.core.processor.StringDelimitedProcessor
 import com.twitter.hbc.core.endpoint.Location
 import com.twitter.hbc.httpclient.auth.OAuth1
-import org.apache.kafka.connect.source.SourceTaskContext
+import org.apache.kafka.connect.source.{SourceRecord, SourceTaskContext}
+import twitter4j.Status
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
 
@@ -66,6 +67,12 @@ object TwitterReader {
     //queue for client to buffer to
     val queue = new LinkedBlockingQueue[String](10000)
 
+    //how the output is formatted
+    val statusConverter = config.getString(TwitterSourceConfig.OUTPUT_FORMAT) match {
+      case TwitterSourceConfig.OUTPUT_FORMAT_ENUM_STRING => StatusToStringKeyValue
+      case TwitterSourceConfig.OUTPUT_FORMAT_ENUM_STRUCTURED => StatusToTwitterStatusStructure
+    }
+
     //build basic client
     val client = new ClientBuilder()
       .name(config.getString(TwitterSourceConfig.TWITTER_APP_NAME))
@@ -76,6 +83,6 @@ object TwitterReader {
       .build()
 
     new TwitterStatusReader(client = client, rawQueue = queue, batchSize = batchSize, 
-        batchTimeout = batchTimeout, topic = topic)
+        batchTimeout = batchTimeout, topic = topic, statusConverter = statusConverter)
   }
 }

--- a/src/main/scala/com/eneco/trading/kafka/connect/twitter/TwitterSourceConfig.scala
+++ b/src/main/scala/com/eneco/trading/kafka/connect/twitter/TwitterSourceConfig.scala
@@ -45,6 +45,11 @@ object TwitterSourceConfig {
   val TOPIC_DEFAULT = "tweets"
   val LANGUAGE = "language"
   val LANGUAGE_DOC = "List of languages to filter"
+  val OUTPUT_FORMAT = "output.format"
+  val OUTPUT_FORMAT_ENUM_STRUCTURED = "structured"
+  val OUTPUT_FORMAT_ENUM_STRING = "string"
+  val OUTPUT_FORMAT_DOC = s"How the output is formatted, can be either ${OUTPUT_FORMAT_ENUM_STRING} for (key=username:string, value=text:string), or ${OUTPUT_FORMAT_ENUM_STRUCTURED} for value=structure:TwitterStatus."
+  val OUTPUT_FORMAT_DEFAULT = "structured"
   val EMPTY_VALUE = ""
 
   val config: ConfigDef = new ConfigDef()
@@ -61,6 +66,7 @@ object TwitterSourceConfig {
     .define(BATCH_TIMEOUT, Type.DOUBLE, BATCH_TIMEOUT_DEFAULT, Importance.MEDIUM, BATCH_TIMEOUT_DOC)
     .define(TOPIC, Type.STRING, TOPIC_DEFAULT, Importance.HIGH, TOPIC_DOC)
     .define(LANGUAGE, Type.LIST, EMPTY_VALUE, Importance.MEDIUM, LANGUAGE_DOC)
+    .define(OUTPUT_FORMAT, Type.STRING, OUTPUT_FORMAT_DEFAULT, Importance.MEDIUM, OUTPUT_FORMAT_DOC)
 }
 
 class TwitterSourceConfig(props: util.Map[String, String])


### PR DESCRIPTION
Simple source mode. Allow the source to output username/tweet-text as key/values in plain string format.