### PR TITLE
Use date from status, not current date

### DIFF
--- a/src/main/scala/com/eneco/trading/kafka/connect/twitter/domain/TwitterStatus.scala
+++ b/src/main/scala/com/eneco/trading/kafka/connect/twitter/domain/TwitterStatus.scala
@@ -38,7 +38,7 @@ object TwitterStatus {
     val tz = TimeZone.getTimeZone("UTC")
     val df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
     df.setTimeZone(tz)
-    df.format(new Date())
+    df.format(if (d == null) { new Date() } else { d })
   }
 
   def apply(s: Status) = {

--- a/src/main/scala/com/eneco/trading/kafka/connect/twitter/domain/TwitterStatus.scala
+++ b/src/main/scala/com/eneco/trading/kafka/connect/twitter/domain/TwitterStatus.scala
@@ -36,7 +36,7 @@ object TwitterUser {
 object TwitterStatus {
   def asIso8601String(d:Date) = {
     val tz = TimeZone.getTimeZone("UTC")
-    val df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mmZ")
+    val df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
     df.setTimeZone(tz)
     df.format(new Date())
   }


### PR DESCRIPTION
In previous version of code, the current timestamp was always used, not the date from Status class.
This change fixes this...

P.S. Sorry, that I include previous PR - forgot to do pull before committing my code...