### PR TITLE
Put Tweet's timestamp into SourceRecord

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <java.version>1.8</java.version>
         <scala.version>2.11.7</scala.version>
         <confluent.version>3.0.0</confluent.version>
-        <kafka.version>0.10.0.0</kafka.version>
+        <kafka.version>0.10.1.0</kafka.version>
         <hosebird.version>2.2.0</hosebird.version>
         <avro.version>1.7.7</avro.version>
         <slf4j.version>1.7.13</slf4j.version>

--- a/src/main/scala/com/eneco/trading/kafka/connect/twitter/TwitterStatusReader.scala
+++ b/src/main/scala/com/eneco/trading/kafka/connect/twitter/TwitterStatusReader.scala
@@ -42,7 +42,8 @@ object StatusToStringKeyValue extends StatusToSourceRecord {
       Schema.STRING_SCHEMA,
       status.getUser.getScreenName,
       Schema.STRING_SCHEMA,
-      status.getText)
+      status.getText,
+      status.getCreatedAt.getTime)
   }
 }
 
@@ -53,8 +54,12 @@ object StatusToTwitterStatusStructure extends StatusToSourceRecord {
       Map("tweetSource" -> status.getSource).asJava, //source partitions?
       Map("tweetId" -> status.getId).asJava, //source offsets?
       topic,
+      null,
+      null,
+      null,
       TwitterStatus.schema,
-      TwitterStatus.struct(status))
+      TwitterStatus.struct(status),
+      status.getCreatedAt.getTime)
   }
 }
 


### PR DESCRIPTION
Since Kafka 0.10.1.0 it's possible to set timestamp for SourceRecord. This pull request sets the Tweet's timestamp into record instead of relying on timestamp set by producer.

This should improve handling of timestamps for aggregations, etc.