### PR TITLE
Add key while creating SourceRecord for structured data

### DIFF
--- a/src/main/scala/com/eneco/trading/kafka/connect/twitter/TwitterStatusReader.scala
+++ b/src/main/scala/com/eneco/trading/kafka/connect/twitter/TwitterStatusReader.scala
@@ -55,8 +55,8 @@ object StatusToTwitterStatusStructure extends StatusToSourceRecord {
       Map("tweetId" -> status.getId).asJava, //source offsets?
       topic,
       null,
-      null,
-      null,
+      Schema.STRING_SCHEMA,
+      status.getUser.getScreenName,
       TwitterStatus.schema,
       TwitterStatus.struct(status),
       status.getCreatedAt.getTime)


### PR DESCRIPTION
In the current version, Source Records with structured output format are only being written to 1 partition of topic even though other partitions are available. This was severely constraining our consumers from parallel consumption of data. We have fixed this by adding the key as user screen name with schema type String. This has made no effect to the data being produced in structured format, but has led to even distribution of data across all partitions hence reducing processing time with multiple consumers in same group.